### PR TITLE
FIX: Bug when reading initials of more than one vector state

### DIFF
--- a/core/echse_coreClass_abstractObject.cpp
+++ b/core/echse_coreClass_abstractObject.cpp
@@ -950,8 +950,8 @@ void abstractObject::init_statesVect(const table &tab) {
         // Save values and clear temporarys
         statesVect.add(tmp);        
         tmp.clear();
-        tab_subset.clear();
       } // End of loop over state variables
+      tab_subset.clear();
     }
   } catch (except) {
     stringstream errmsg;


### PR DESCRIPTION
There was a bug during reading of initial values of vector state variables when more than one vector state variable was defined (table object cleared within vector variable loop).
